### PR TITLE
Check for Ruffle stubs using any warning phrases

### DIFF
--- a/buildtable.py
+++ b/buildtable.py
@@ -636,10 +636,10 @@ for subdir, dirs, files in os.walk(dir):
 # Find "Not implemented in all features to set as partially complete"
 for subdir, dirs, files in os.walk(dir):
     for file in files:
-        if file.endswith('.rs'):
+        if file.endswith('.rs') or file.endswith('.rs'):
             fileContent = open(os.path.join(subdir, file), "r")
             lines = fileContent.read()
-            m = re.findall('log\:\:warn\!\(\"(.*)\..* not implemented\"\)', lines)
+            m = re.findall('log(\:\:|_)warn\!?\(\"(.*)\..* ([n|N]ot.* implemented|is a stub)\"\)', lines)
             for item in matrix:
                 for found in m:
                     if found in matrix[item].keys():


### PR DESCRIPTION
Compare with the results of https://github.com/search?l=Rust&q=log%3A%3Awarn+repo%3Aruffle-rs%2Fruffle+path%3Acore%2Fsrc%2Favm2%2Fglobals%2Fflash&type=Code and https://github.com/search?l=ActionScript&q=log_warn+repo%3Aruffle-rs%2Fruffle+path%3Acore%2Fsrc%2Favm2%2Fglobals%2Fflash&type=Code using Regex101. Fixes #2.